### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ EXAMPLE
 ```hcl
 module "spoke-1" {
   source = "dcos-terraform/dcos/aws-remote-agents"
-  version = "~> 0.1"
+  version = "0.1.0"
 
   provider "aws" {
     region = "us-west-2"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *```hcl
  *  module "spoke-1" {
  *    source = "dcos-terraform/dcos/aws-remote-agents"
- *    version = "~> 0.1"
+ *    version = "0.1.0"
  *  
  *    provider "aws" {
  *      region = "us-west-2"
@@ -36,7 +36,7 @@ locals {
 
 module "dcos-infrastructure" {
   source  = "dcos-terraform/infrastructure/aws"
-  version = "~> 0.1"
+  version = "0.1.0"
 
   admin_ips                                  = "${var.admin_ips}"
   availability_zones                         = "${var.availability_zones}"
@@ -84,7 +84,7 @@ module "dcos-infrastructure" {
 
 module "dcos-install" {
   source  = "dcos-terraform/dcos-install-remote-exec/null"
-  version = "~> 0.0"
+  version = "0.0.0"
 
   # bootstrap
   bootstrap_ip         = "${coalesce(var.bootstrap_ip, module.dcos-infrastructure.bootstrap.public_ip)}"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2